### PR TITLE
Add trailing comma after arguments

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -76,7 +76,9 @@ Style/StringLiterals:
 Style/SymbolArray:
   Enabled: false
 Style/TrailingCommaInArguments:
-  EnforcedStyleForMultiline: consistent_comma  
+  EnforcedStyleForMultiline: consistent_comma
+  Exclude:
+    - "bin/*"
 Style/TrailingCommaInLiteral:
   EnforcedStyleForMultiline: consistent_comma
 Style/UnneededInterpolation:

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -8,7 +8,7 @@ module Admin
     def require_admin
       unless current_user.admin?
         redirect_to users_path, alert: I18n.t(
-          "admin.defaults.require_admin"
+          "admin.defaults.require_admin",
         )
       end
     end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -27,7 +27,7 @@ module Admin
       user.delete
       flash[:notice] = I18n.t(
         "flash.actions.destroy.notice",
-        resource_name: "User"
+        resource_name: "User",
       )
 
       redirect_to admin_users_path

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,7 +18,7 @@ class ApplicationController < ActionController::Base
   def require_login
     unless current_user
       redirect_to new_session_path, alert: I18n.t(
-        "sessions.new.flash.require_login"
+        "sessions.new.flash.require_login",
       )
     end
   end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -36,7 +36,7 @@ describe UsersController do
         get :show
 
         expect(flash[:alert]).to match I18n.t(
-          "sessions.new.flash.require_login"
+          "sessions.new.flash.require_login",
         )
       end
     end

--- a/spec/features/admin/admin_creates_new_admin_account_spec.rb
+++ b/spec/features/admin/admin_creates_new_admin_account_spec.rb
@@ -19,8 +19,8 @@ feature "admin creates new admin account" do
     expect(page).
       to have_text(I18n.t(
         "flash.actions.create.notice",
-        resource_name: "User"
-      ))
+        resource_name: "User",
+      ),)
     within "#user_#{user.id}" do
       expect(page).to have_text("Mary")
       expect(page).to have_text("true")

--- a/spec/features/admin/admin_deletes_user_spec.rb
+++ b/spec/features/admin/admin_deletes_user_spec.rb
@@ -15,7 +15,7 @@ feature "admin deletes user" do
     expect(page).
       to have_text(I18n.t(
         "flash.actions.destroy.notice",
-        resource_name: "User"
-      ))
+        resource_name: "User",
+      ),)
   end
 end

--- a/spec/features/admin/admin_edits_user_spec.rb
+++ b/spec/features/admin/admin_edits_user_spec.rb
@@ -20,8 +20,8 @@ feature "Admin edits user" do
     expect(page).
       to have_text(I18n.t(
         "flash.actions.update.notice",
-        resource_name: "User"
-      ))
+        resource_name: "User",
+      ),)
     within "#user_#{user.id}" do
       expect(page).to have_text("Mary")
     end

--- a/spec/features/sessions/user_creates_new_session_spec.rb
+++ b/spec/features/sessions/user_creates_new_session_spec.rb
@@ -17,7 +17,7 @@ feature "user creates new session" do
 
     expect(page).to have_text(I18n.t("home.show.welcome"))
     expect(page).to have_text(
-      I18n.t("sessions.destroy.flash.notice", resource_name: "Session")
+      I18n.t("sessions.destroy.flash.notice", resource_name: "Session"),
     )
   end
 end

--- a/spec/features/users/user_creates_new_account_spec.rb
+++ b/spec/features/users/user_creates_new_account_spec.rb
@@ -16,7 +16,7 @@ feature "user creates new account" do
     expect(page).not_to have_text(I18n.t(
       "flash.actions.create.notice",
       resource_name: "User",
-    ))
+    ),)
     expect(current_path).to eq(users_path)
   end
 end

--- a/spec/features/users/user_updates_profile_spec.rb
+++ b/spec/features/users/user_updates_profile_spec.rb
@@ -15,7 +15,7 @@ feature "user updates profile" do
     expect(page).
       to have_text(I18n.t(
         "flash.actions.update.notice",
-        resource_name: "User"
-      ))
+        resource_name: "User",
+      ),)
   end
 end


### PR DESCRIPTION
PR to fix Rubobop violations for no consistent comma after arguments.
Feedback welcome.

https://trello.com/c/QcYj6OJ6
Thanks for taking a look!